### PR TITLE
Fix router crash

### DIFF
--- a/src/components/environments/Frame.js
+++ b/src/components/environments/Frame.js
@@ -1,6 +1,5 @@
 import React, { PropTypes, Component } from 'react'
 import './../../styles/environments/Frame.css'
-import { browserHistory } from 'react-router'
 
 import {
   Navbar,
@@ -16,13 +15,14 @@ import { routes } from './../../index'
 class Frame extends Component {
 
   handleSelect(selectedKey) {
-    browserHistory.push(routes[selectedKey].path)
+    this.props.history.push(routes[selectedKey].path)
   }
 
   getActiveRouteIndex() {
-    const path = window.location.pathname
+    let hash = window.location.hash
+    hash = hash.substring(hash.indexOf('#') + 1, hash.indexOf('?'))
     return routes.findIndex(route => {
-      return route.path === path
+      return hash === route.path
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {render} from 'react-dom'
 
-import { Router, Route, browserHistory, IndexRoute } from 'react-router'
+import { Router, Route, hashHistory, IndexRoute } from 'react-router'
 
 import { Provider } from 'react-redux'
 import { createStore,  applyMiddleware } from 'redux'
@@ -38,7 +38,7 @@ store.dispatch(getAccounts())
 
 render(
   <Provider store={store}>
-    <Router history={browserHistory}>
+    <Router history={hashHistory}>
       <Route path="/" component={Frame}>
         <IndexRoute component={Home} />
         {

--- a/src/redux/actions/connection-actions.js
+++ b/src/redux/actions/connection-actions.js
@@ -72,7 +72,6 @@ export function watchNetworkStatus() {
     const latestStatus = web3.eth.filter('latest')
 
     latestStatus.watch((err, blockHash) => {
-
       return new Promise((resolve, reject) => {
         web3.eth.getBlock(blockHash, false, function(err, block) {
           if (err) reject(err)

--- a/src/redux/actions/connection-actions.js
+++ b/src/redux/actions/connection-actions.js
@@ -7,7 +7,7 @@ else if (typeof Web3 !== 'undefined') {
   web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
   if (!web3.isConnected()) {
     const Web3 = require('web3')
-    web3 = new Web3(new Web3.providers.HttpProvider('https://signal.ether.ai/proxy'))
+    web3 = new Web3(new Web3.providers.HttpProvider('http://rpc.ethapi.org:8545'))
   }
 }
 

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -1,5 +1,3 @@
-const API_KEY = process.env.ETHERSCAN_API_KEY
-
 import querystring from 'querystring'
 import fetch from 'isomorphic-fetch'
 import getSignalPerBlock from './utils/getSignalPerBlock'
@@ -20,7 +18,7 @@ else if (typeof Web3 !== 'undefined') {
   web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
   if (!web3.isConnected()) {
     const Web3 = require('web3')
-    web3 = new Web3(new Web3.providers.HttpProvider('https://signal.ether.ai/proxy'))
+    web3 = new Web3(new Web3.providers.HttpProvider('http://rpc.ethapi.org:8545'))
   }
 }
 

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -397,13 +397,20 @@ export function submitNewPosition(title, description, account) {
   return dispatch => {
     dispatch(submitNewPositionRequest())
     try {
-      const result = positionRegistry.registerPosition.sendTransaction(
-        title,
-        description,
-        { from: sender, to: address, gas: gas }
+      positionRegistry.registerPosition.sendTransaction(
+        {
+          title,
+          description,
+          from: sender,
+          to: address,
+          gas: gas
+        },
+        (err, result) => {
+          if (err) throw err
+          dispatch(addTimedAlert('The position was submitted!', 'success'))
+          dispatch(submitNewPositionSuccess(result))
+        }
       )
-      dispatch(addTimedAlert('The position was submitted!', 'success'))
-      dispatch(submitNewPositionSuccess(result))
     }
     catch (error) {
       dispatch(addTimedAlert(error.message, 'danger'))

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -94,12 +94,12 @@ function getPositions(fromBlock, endBlock) {
 
 function getPositionDeposit(position) {
   return new Promise((resolve, reject) => {
-    const block = web3.eth.getBlock(position.blockNumber)
-    const deposit = Number(web3.fromWei(
-      web3.eth.getBalance(position.args.sigAddr),
-      'finney'
-    ))
-    resolve(Object.assign({}, position, {block, deposit}))
+    web3.eth.getBlock(position.blockNumber, (err, block) => {
+      web3.eth.getBalance(position.args.sigAddr, (err, balance) => {
+        const deposit = Number(web3.fromWei(balance, 'finney'))
+        resolve(Object.assign({}, position, {block, deposit}))
+      })
+    })
   })
 }
 
@@ -170,6 +170,7 @@ function calculateCurrentSignal(position) {
     for (const address in position.proMap) {
 
       const balance = web3.fromWei(web3.eth.getBalance(address))
+
       position.proMap[address] = position.proMap[address] * balance
       position.againstMap[address] = position.againstMap[address] * balance
 
@@ -187,6 +188,7 @@ function calculateCurrentSignal(position) {
           }
         }
       })
+
     }
 
     for (const index in web3.eth.accounts) {

--- a/src/redux/actions/position-actions.js
+++ b/src/redux/actions/position-actions.js
@@ -392,30 +392,34 @@ export function submitNewPosition(title, description, account) {
   // Todo: there should be an account selector
   const sender = account
   const data = positionRegistry.registerPosition.getData(title, description)
-  const gas = web3.eth.estimateGas({from: sender, to: address, data: data})
 
   return dispatch => {
     dispatch(submitNewPositionRequest())
-    try {
-      positionRegistry.registerPosition.sendTransaction(
-        {
+    web3.eth.estimateGas({from: sender, to: address, data: data}, (err, gas) => {
+      try {
+        positionRegistry.registerPosition.sendTransaction(
           title,
           description,
-          from: sender,
-          to: address,
-          gas: gas
-        },
-        (err, result) => {
-          if (err) throw err
-          dispatch(addTimedAlert('The position was submitted!', 'success'))
-          dispatch(submitNewPositionSuccess(result))
-        }
-      )
-    }
-    catch (error) {
-      dispatch(addTimedAlert(error.message, 'danger'))
-      dispatch(submitNewPositionFailure(error))
-    }
+          {
+            from: sender,
+            to: address,
+            gas: gas
+          },
+          (err, result) => {
+            if (err) throw err
+            dispatch(addTimedAlert('The position was submitted!', 'success'))
+            dispatch(submitNewPositionSuccess(result))
+          }
+        )
+      }
+
+      catch (error) {
+        dispatch(addTimedAlert(error.message, 'danger'))
+        dispatch(submitNewPositionFailure(error))
+      }
+
+    })
+
   }
 
 }


### PR DESCRIPTION
Includes PRs #40, #41.  

Replace `browserHistory` with `hashHistory`, as the former causes the app to crash when deployed to gh-pages.
